### PR TITLE
feat: database layer — Prisma + PostgreSQL schema, db.ts module

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://placeholder:placeholder@host.db.supabase.co:5432/postgres"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+
+# PostgreSQL (Supabase)
+DATABASE_URL=postgresql://user:password@host.db.supabase.co:5432/postgres

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@prisma/client": "5.22.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "lucide-react": "^1.7.0",
         "next": "14.2.35",
+        "prisma": "5.22.0",
         "react": "^18",
         "react-dom": "^18",
         "shadcn": "^4.2.0",
@@ -1530,6 +1532,69 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
+      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
+      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
+      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/fetch-engine": "5.22.0",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
+      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
+      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
+      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -5093,7 +5158,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7813,6 +7877,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
+      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/engines": "5.22.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
       }
     },
     "node_modules/prompts": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@prisma/client": "5.22.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "lucide-react": "^1.7.0",
     "next": "14.2.35",
+    "prisma": "5.22.0",
     "react": "^18",
     "react-dom": "^18",
     "shadcn": "^4.2.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,27 @@
+// This is your Prisma schema file,
+// learn more about it in our docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Project {
+  id           String   @id @default(cuid())
+  name         String
+  status       String   @default("idle")
+  githubRepo   String?
+  vercelUrl    String?
+  researchData Json?
+  ideas        Json?
+  selectedIdea Json?
+  events       Json     @default("[]")
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@map("projects")
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,78 @@
+/**
+ * Database Layer — Prisma + PostgreSQL (Supabase)
+ *
+ * Setup:
+ *   1. npm install
+ *   2. npx prisma generate       # generate Prisma client
+ *   3. npx prisma migrate dev    # run migrations (requires DATABASE_URL)
+ *
+ * The DB layer is a drop-in replacement for the in-memory Map in projects.ts.
+ * Set DATABASE_URL in .env to enable persistence.
+ */
+
+import type { PrismaClient as PrismaClientType } from "@prisma/client";
+
+let _prisma: PrismaClientType | null = null;
+
+async function getPrisma(): Promise<PrismaClientType> {
+  if (_prisma) return _prisma;
+  const { PrismaClient } = await import("@prisma/client");
+  _prisma = new PrismaClient();
+  return _prisma;
+}
+
+// ─── Project CRUD ────────────────────────────────────────
+
+export async function dbCreateProject(name: string) {
+  const prisma = await getPrisma();
+  return prisma.project.create({
+    data: {
+      name,
+      status: "idle",
+      events: { createdAt: new Date().toISOString(), type: "info", message: "Project created" },
+    },
+  });
+}
+
+export async function dbGetProject(id: string) {
+  const prisma = await getPrisma();
+  return prisma.project.findUnique({ where: { id } });
+}
+
+export async function dbGetAllProjects() {
+  const prisma = await getPrisma();
+  return prisma.project.findMany({ orderBy: { createdAt: "desc" } });
+}
+
+export async function dbUpdateProject(id: string, data: Record<string, unknown>) {
+  const prisma = await getPrisma();
+  return prisma.project.update({ where: { id }, data: data as Parameters<typeof prisma.project.update>[0]["data"] });
+}
+
+export async function dbDeleteProject(id: string) {
+  const prisma = await getPrisma();
+  return prisma.project.delete({ where: { id } });
+}
+
+export async function dbAddEvent(
+  id: string,
+  message: string,
+  type: "info" | "success" | "warning" | "error"
+) {
+  const project = await dbGetProject(id);
+  if (!project) return;
+  const events = (project.events as Array<{ type: string; message: string; timestamp: string }>) ?? [];
+  events.push({ type, message, timestamp: new Date().toISOString() });
+  return dbUpdateProject(id, { events });
+}
+
+export async function dbConnect() {
+  const prisma = await getPrisma();
+  await prisma.$connect();
+}
+
+export async function dbDisconnect() {
+  if (_prisma) {
+    await (_prisma as PrismaClientType).$disconnect();
+  }
+}


### PR DESCRIPTION
## What

Closes #6 — Project database + state management

New files:
- `prisma/schema.prisma` — Project model with id, name, status, githubRepo, vercelUrl, researchData (JSON), ideas (JSON), selectedIdea (JSON), events (JSON), timestamps
- `src/lib/db.ts` — DB layer: `dbCreateProject`, `dbGetProject`, `dbGetAllProjects`, `dbUpdateProject`, `dbDeleteProject`, `dbAddEvent`, `dbConnect`, `dbDisconnect`

Updated `.env.example`:
- Added `DATABASE_URL` for Supabase PostgreSQL
- Added Prisma 5 for stability

Build passes ✅. Prisma 5.x (not 7.x) used for compatibility.

## Files
- `prisma/schema.prisma` — database schema
- `src/lib/db.ts` — DB layer module
- `.env` + `.env.example` — env vars
- `package.json` — Prisma added