### PR TITLE
fix: polling detail page, delete API, 2-step idea picker

### DIFF
--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getProject } from "@/lib/projects";
+import { getProject, deleteProject } from "@/lib/projects";
 import { selectIdeaAndBuild, deployProject } from "@/lib/orchestrator";
 
 // GET /api/projects/[id] — get a single project
@@ -69,4 +69,19 @@ export async function POST(
       { status: 500 }
     );
   }
+}
+
+// DELETE /api/projects/[id] — delete a project
+export async function DELETE(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const existed = deleteProject(params.id);
+  if (!existed) {
+    return NextResponse.json(
+      { success: false, error: "Project not found" },
+      { status: 404 }
+    );
+  }
+  return NextResponse.json({ success: true });
 }

--- a/src/app/dashboard/[id]/page.tsx
+++ b/src/app/dashboard/[id]/page.tsx
@@ -1,26 +1,58 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useParams } from "next/navigation";
 import { ProjectDetail } from "@/components/dashboard/project-detail";
 import type { SaaSProject } from "@/lib/projects";
 import { Skeleton } from "@/components/ui/skeleton";
+
+const POLL_INTERVAL = 5000; // 5 seconds
+
+// Terminal statuses — stop polling
+const TERMINAL = new Set(["idle", "live"]);
+// Interactive statuses — stop polling, wait for user
+const AWAITING_INPUT = new Set(["selecting"]);
 
 export default function ProjectPage() {
   const params = useParams();
   const id = params?.id as string;
   const [project, setProject] = useState<SaaSProject | null>(null);
   const [loading, setLoading] = useState(true);
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => {
+  function stopPolling() {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+  }
+
+  function fetchProject() {
     if (!id) return;
     fetch(`/api/projects/${id}`)
       .then((res) => res.json())
       .then((data) => {
-        if (data.success) setProject(data.project);
+        if (data.success) {
+          setProject(data.project);
+          const status = data.project.status;
+          // Stop polling on terminal or user-input statuses
+          if (TERMINAL.has(status) || AWAITING_INPUT.has(status)) {
+            stopPolling();
+          }
+        }
       })
       .catch(() => {})
       .finally(() => setLoading(false));
+  }
+
+  useEffect(() => {
+    if (!id) return;
+    fetchProject(); // Initial fetch
+
+    // Start polling
+    pollingRef.current = setInterval(fetchProject, POLL_INTERVAL);
+
+    return () => stopPolling();
   }, [id]);
 
   if (loading) {

--- a/src/components/dashboard/new-project-sheet.tsx
+++ b/src/components/dashboard/new-project-sheet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -11,17 +12,24 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { Input } from "@/components/ui/input";
-import { Sparkles, Loader2 } from "lucide-react";
+import { Sparkles, Loader2, CheckCircle2 } from "lucide-react";
+import type { GeneratedIdea } from "@/lib/projects";
 
 export function NewProjectSheet() {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const [niche, setNiche] = useState("");
   const [loading, setLoading] = useState(false);
+  const [ideas, setIdeas] = useState<GeneratedIdea[] | null>(null);
+  const [projectId, setProjectId] = useState<string | null>(null);
+  const [selectedIdeaIdx, setSelectedIdeaIdx] = useState<number | null>(null);
+  const [selecting, setSelecting] = useState(false);
 
   async function handleGenerate() {
     if (!name.trim()) return;
     setLoading(true);
+    setIdeas(null);
 
     try {
       const res = await fetch("/api/generate", {
@@ -34,100 +42,197 @@ export function NewProjectSheet() {
       });
 
       const data = await res.json();
-      if (data.success) {
-        setOpen(false);
-        setName("");
-        setNiche("");
-        // Refresh the page to show new project
-        window.location.reload();
+      if (data.success && data.ideas) {
+        setIdeas(data.ideas);
+        setProjectId(data.project?.id ?? null);
+      } else {
+        alert(data.error ?? "Generation failed");
+        setLoading(false);
       }
     } catch {
-      // Handle error
-    } finally {
+      alert("Network error — please try again");
       setLoading(false);
     }
   }
 
+  async function handleSelectIdea(idx: number) {
+    if (!projectId) return;
+    setSelectedIdeaIdx(idx);
+    setSelecting(true);
+
+    try {
+      const res = await fetch(`/api/projects/${projectId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "select-idea", ideaIndex: idx }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setOpen(false);
+        setName("");
+        setNiche("");
+        setIdeas(null);
+        setProjectId(null);
+        setSelectedIdeaIdx(null);
+        router.push(`/dashboard/${projectId}`);
+      } else {
+        alert(data.error ?? "Failed to start build");
+      }
+    } catch {
+      alert("Network error — please try again");
+    } finally {
+      setSelecting(false);
+      setSelectedIdeaIdx(null);
+    }
+  }
+
+  function handleClose() {
+    setOpen(false);
+    setLoading(false);
+    setIdeas(null);
+    setProjectId(null);
+    setSelectedIdeaIdx(null);
+  }
+
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
+    <Sheet open={open} onOpenChange={(v) => v === false && handleClose()}>
       <SheetTrigger>
-        <Button className="bg-violet-600 hover:bg-violet-700 text-white">
-          <Sparkles className="h-4 w-4 mr-2" />
+        <span className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-700 text-white text-sm font-semibold cursor-pointer">
+          <Sparkles className="h-4 w-4" />
           New Project
-        </Button>
+        </span>
       </SheetTrigger>
-      <SheetContent className="bg-zinc-950 border-zinc-800">
+      <SheetContent className="bg-zinc-950 border-zinc-800 overflow-y-auto">
         <SheetHeader>
           <SheetTitle className="text-zinc-100">
-            Generate a new SaaS
+            {ideas ? "Choose your idea" : "Generate a new SaaS"}
           </SheetTitle>
           <SheetDescription className="text-zinc-500">
-            AI will research the market, generate ideas, and build the app.
+            {ideas
+              ? "Pick the idea you like best — agents will start building immediately."
+              : "AI will research the market, generate ideas, and build the app."}
           </SheetDescription>
         </SheetHeader>
 
-        <div className="mt-8 space-y-6">
-          <div className="space-y-2">
-            <label className="text-xs font-medium text-zinc-400">
-              Project Name
-            </label>
-            <Input
-              placeholder="e.g., InvoicePilot"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="bg-zinc-900 border-zinc-800 text-zinc-100 placeholder:text-zinc-600 focus:border-violet-600"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <label className="text-xs font-medium text-zinc-400">
-              Niche (optional)
-            </label>
-            <Input
-              placeholder="e.g., AI invoicing for freelancers"
-              value={niche}
-              onChange={(e) => setNiche(e.target.value)}
-              className="bg-zinc-900 border-zinc-800 text-zinc-100 placeholder:text-zinc-600 focus:border-violet-600"
-            />
-            <p className="text-[10px] text-zinc-600">
-              Leave blank to let AI find the best niche for you
-            </p>
-          </div>
-
-          <div className="pt-4 border-t border-zinc-800">
-            <div className="rounded-lg bg-zinc-900 border border-zinc-800 p-4 space-y-3">
-              <p className="text-xs font-medium text-zinc-400">
-                What happens next:
-              </p>
-              <ol className="text-[11px] text-zinc-500 space-y-1.5">
-                <li>1. AI researches the market and competition</li>
-                <li>2. 3 SaaS ideas generated with validation scores</li>
-                <li>3. You pick your favorite idea</li>
-                <li>4. GitHub repo created with MVP issues</li>
-                <li>5. Specialist agents build in parallel</li>
-                <li>6. Code reviewed and deployed to Vercel</li>
-              </ol>
+        {!ideas ? (
+          // ─── Step 1: Enter project name ───
+          <div className="mt-8 space-y-6">
+            <div className="space-y-2">
+              <label className="text-xs font-medium text-zinc-400">
+                Project Name
+              </label>
+              <Input
+                placeholder="e.g., InvoicePilot"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="bg-zinc-900 border-zinc-800 text-zinc-100 placeholder:text-zinc-600 focus:border-violet-600"
+              />
             </div>
-          </div>
 
-          <Button
-            onClick={handleGenerate}
-            disabled={!name.trim() || loading}
-            className="w-full bg-violet-600 hover:bg-violet-700 text-white"
-          >
-            {loading ? (
-              <>
-                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                Generating...
-              </>
-            ) : (
-              <>
-                <Sparkles className="h-4 w-4 mr-2" />
-                Start Generation
-              </>
-            )}
-          </Button>
-        </div>
+            <div className="space-y-2">
+              <label className="text-xs font-medium text-zinc-400">
+                Niche (optional)
+              </label>
+              <Input
+                placeholder="e.g., AI invoicing for freelancers"
+                value={niche}
+                onChange={(e) => setNiche(e.target.value)}
+                className="bg-zinc-900 border-zinc-800 text-zinc-100 placeholder:text-zinc-600 focus:border-violet-600"
+              />
+              <p className="text-[10px] text-zinc-600">
+                Leave blank to let AI find the best niche for you
+              </p>
+            </div>
+
+            <div className="pt-4 border-t border-zinc-800">
+              <div className="rounded-lg bg-zinc-900 border border-zinc-800 p-4 space-y-3">
+                <p className="text-xs font-medium text-zinc-400">
+                  What happens next:
+                </p>
+                <ol className="text-[11px] text-zinc-500 space-y-1.5">
+                  <li>1. AI researches the market and competition</li>
+                  <li>2. 3 SaaS ideas generated with validation scores</li>
+                  <li>3. You pick your favorite idea</li>
+                  <li>4. GitHub repo created with MVP issues</li>
+                  <li>5. Specialist agents build in parallel</li>
+                  <li>6. Code reviewed and deployed to Vercel</li>
+                </ol>
+              </div>
+            </div>
+
+            <Button
+              onClick={handleGenerate}
+              disabled={!name.trim() || loading}
+              className="w-full bg-violet-600 hover:bg-violet-700 text-white"
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Researching...
+                </>
+              ) : (
+                <>
+                  <Sparkles className="h-4 w-4 mr-2" />
+                  Start Generation
+                </>
+              )}
+            </Button>
+          </div>
+        ) : (
+          // ─── Step 2: Pick an idea ───
+          <div className="mt-8 space-y-4">
+            <p className="text-xs text-zinc-400">
+              Found {ideas.length} ideas for <span className="text-zinc-200">{name}</span>:
+            </p>
+            {ideas.map((idea, i) => (
+              <button
+                key={i}
+                onClick={() => handleSelectIdea(i)}
+                disabled={selecting}
+                className="w-full text-left rounded-lg border border-zinc-800 bg-zinc-900 p-4 hover:border-violet-600 transition-colors disabled:opacity-50"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex-1 min-w-0">
+                    <p className="font-semibold text-zinc-100 text-sm">
+                      {idea.name}
+                    </p>
+                    <p className="text-xs text-zinc-400 mt-0.5">{idea.tagline}</p>
+                    <p className="text-[10px] text-zinc-500 mt-1 truncate">
+                      {idea.monetization}
+                    </p>
+                  </div>
+                  <div className="shrink-0 text-right">
+                    <span
+                      className={`text-xs font-bold ${
+                        idea.validationScore >= 80
+                          ? "text-emerald-400"
+                          : idea.validationScore >= 65
+                          ? "text-amber-400"
+                          : "text-zinc-500"
+                      }`}
+                    >
+                      {idea.validationScore}
+                    </span>
+                    <p className="text-[10px] text-zinc-600">score</p>
+                  </div>
+                </div>
+                {selectedIdeaIdx === i && (
+                  <div className="mt-2 flex items-center gap-1 text-violet-400 text-xs">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    Starting build...
+                  </div>
+                )}
+              </button>
+            ))}
+
+            <button
+              onClick={handleClose}
+              className="w-full text-center text-xs text-zinc-500 hover:text-zinc-300 py-2"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
       </SheetContent>
     </Sheet>
   );

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -183,3 +183,7 @@ export function updateProject(
   projects.set(projectId, project);
   return project;
 }
+
+export function deleteProject(projectId: string): boolean {
+  return projects.delete(projectId);
+}


### PR DESCRIPTION
Dashboard UX improvements:
- Project detail page: auto-polls every 5s while in-progress (researching/building/etc), stops on idle/live/selecting
- DELETE /api/projects/[id]: delete a project from in-memory store
- New Project Sheet: 2-step flow — enter name/niche → shows 3 ideas with scores → click idea to select and redirect to detail
Build passes 0 errors ✅