### PR TITLE
feat: Prisma DB wiring — User+Project models, dbCreateProject, userId

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
 import {
   initializeProject,
   researchAndGenerateIdeas,
@@ -9,11 +11,14 @@ import { getAllProjects } from "@/lib/projects";
 // NOTE: This is a long-running operation (research + idea generation).
 // It can take 1-3 minutes. Clients should set a long timeout.
 export async function POST(request: Request) {
-  // 5-minute timeout for the full generation pipeline
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 5 * 60 * 1000);
 
   try {
+    const session = await getServerSession(authOptions);
+    // Get userId from session (system placeholder if not authed yet)
+    const userId = (session?.user as { id?: string })?.id ?? undefined;
+
     const body = await request.json();
     const { projectName, niche, description } = body;
 
@@ -29,6 +34,7 @@ export async function POST(request: Request) {
       projectName,
       niche,
       description,
+      userId,
     });
 
     // Step 2: Research + generate ideas
@@ -63,7 +69,7 @@ export async function POST(request: Request) {
   }
 }
 
-// GET /api/generate — list all projects
+// GET /api/generate — list all projects (for in-memory fallback)
 export async function GET() {
   const projects = getAllProjects();
   return NextResponse.json({ success: true, projects });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,18 +1,18 @@
 /**
  * Database Layer — Prisma + PostgreSQL (Supabase)
  *
- * Setup:
- *   1. npm install
- *   2. npx prisma generate       # generate Prisma client
- *   3. npx prisma migrate dev    # run migrations (requires DATABASE_URL)
- *
- * The DB layer is a drop-in replacement for the in-memory Map in projects.ts.
- * Set DATABASE_URL in .env to enable persistence.
+ * Setup (after DATABASE_URL is set in .env):
+ *   npx prisma generate    # generate Prisma client
+ *   npx prisma migrate dev # run migrations
  */
 
 import type { PrismaClient as PrismaClientType } from "@prisma/client";
+import type { Project, User } from "@prisma/client";
 
 let _prisma: PrismaClientType | null = null;
+
+// System user ID used when auth is not yet wired
+const SYSTEM_USER_ID = "system-user";
 
 async function getPrisma(): Promise<PrismaClientType> {
   if (_prisma) return _prisma;
@@ -21,58 +21,94 @@ async function getPrisma(): Promise<PrismaClientType> {
   return _prisma;
 }
 
+// ─── User CRUD ──────────────────────────────────────────
+
+export async function dbUpsertUser({
+  email,
+  name,
+  image,
+}: {
+  email: string;
+  name?: string | null;
+  image?: string | null;
+}): Promise<User> {
+  const prisma = await getPrisma();
+  return prisma.user.upsert({
+    where: { email },
+    update: { name, image },
+    create: { email, name, image, plan: "free" },
+  });
+}
+
+export async function dbGetUser(email: string): Promise<User | null> {
+  const prisma = await getPrisma();
+  return prisma.user.findUnique({ where: { email } });
+}
+
 // ─── Project CRUD ────────────────────────────────────────
 
-export async function dbCreateProject(name: string) {
+export async function dbCreateProject({
+  name,
+  userId,
+}: {
+  name: string;
+  userId?: string;
+}): Promise<Project> {
   const prisma = await getPrisma();
+  const uid = userId ?? SYSTEM_USER_ID;
   return prisma.project.create({
     data: {
       name,
+      userId: uid,
       status: "idle",
-      events: { createdAt: new Date().toISOString(), type: "info", message: "Project created" },
+      events: [],
     },
   });
 }
 
-export async function dbGetProject(id: string) {
+export async function dbGetProject(id: string): Promise<Project | null> {
   const prisma = await getPrisma();
   return prisma.project.findUnique({ where: { id } });
 }
 
-export async function dbGetAllProjects() {
+export async function dbGetAllProjects(opts?: { userId?: string }): Promise<Project[]> {
   const prisma = await getPrisma();
-  return prisma.project.findMany({ orderBy: { createdAt: "desc" } });
+  const where = opts?.userId ? { userId: opts.userId } : {};
+  return prisma.project.findMany({ where, orderBy: { createdAt: "desc" } });
 }
 
-export async function dbUpdateProject(id: string, data: Record<string, unknown>) {
-  const prisma = await getPrisma();
-  return prisma.project.update({ where: { id }, data: data as Parameters<typeof prisma.project.update>[0]["data"] });
-}
-
-export async function dbDeleteProject(id: string) {
-  const prisma = await getPrisma();
-  return prisma.project.delete({ where: { id } });
-}
-
-export async function dbAddEvent(
+export async function dbUpdateProject(
   id: string,
-  message: string,
-  type: "info" | "success" | "warning" | "error"
-) {
-  const project = await dbGetProject(id);
-  if (!project) return;
-  const events = (project.events as Array<{ type: string; message: string; timestamp: string }>) ?? [];
-  events.push({ type, message, timestamp: new Date().toISOString() });
-  return dbUpdateProject(id, { events });
+  data: Partial<Project>
+): Promise<Project> {
+  const prisma = await getPrisma();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return prisma.project.update({ where: { id }, data: data as any });
 }
 
-export async function dbConnect() {
+export async function dbDeleteProject(id: string): Promise<void> {
+  const prisma = await getPrisma();
+  await prisma.project.delete({ where: { id } });
+}
+
+export async function dbIncrementProjectCount(userId: string): Promise<void> {
+  const prisma = await getPrisma();
+  await prisma.user.update({
+    where: { id: userId },
+    data: { projectCount: { increment: 1 } },
+  });
+}
+
+// ─── Connection management ────────────────────────────────
+
+export async function dbConnect(): Promise<void> {
   const prisma = await getPrisma();
   await prisma.$connect();
 }
 
-export async function dbDisconnect() {
+export async function dbDisconnect(): Promise<void> {
   if (_prisma) {
-    await (_prisma as PrismaClientType).$disconnect();
+    await _prisma.$disconnect();
+    _prisma = null;
   }
 }

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -17,7 +17,7 @@ import {
   addEvent,
   type SaaSProject,
 } from "./projects";
-import { dbConnect, dbUpdateProject } from "./db";
+import { dbConnect, dbUpdateProject, dbCreateProject } from "./db";
 import type { GeneratedIdea, ResearchResult } from "./projects";
 import { searchReddit, searchTrends, synthesizeResearch } from "./research";
 import { generateIdeasFromResearch } from "./ideas";
@@ -43,9 +43,14 @@ export interface GenerateResult {
 // ─── Pipeline Steps ─────────────────────────────────────
 
 export async function initializeProject(
-  opts: GenerateOptions
+  opts: GenerateOptions & { userId?: string }
 ): Promise<GenerateResult> {
   const project = createProject(opts.projectName);
+
+  // Persist to DB (non-blocking — errors are logged but don't break the flow)
+  dbCreateProject({ name: opts.projectName, userId: opts.userId }).catch(
+    (err) => console.error("[DB] Failed to create project in DB:", err)
+  );
 
   transitionStatus(project.id, "building", "Creating GitHub repository...", "info");
 


### PR DESCRIPTION
Completes Issue #26.

What was built:
- Updated Prisma schema: User model (email, name, image, stripeCustomerId, plan, projectCount), Project linked to User
- `dbCreateProject()` with userId support
- `dbUpsertUser()` / `dbGetUser()` for user management
- `dbIncrementProjectCount()` to track projects per user
- orchestrator: `initializeProject` now accepts optional `userId` and persists to DB
- generate/route.ts: reads session to get userId (falls back to system placeholder)
- Prisma client generated: `npx prisma generate` ran successfully
- DB writes are async/non-blocking (won't break the pipeline if DB is down)
Build passes ✅

Note: Full migration requires DATABASE_URL to be set. Run `npx prisma migrate dev` once Supabase is configured.